### PR TITLE
Upstream updates and leverage pip role

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,10 +2,9 @@
 # boto3 is installed anywhere we would be applying this Ansible role
 - name: Prepare
   hosts: all
+  roles:
+    - pip
   tasks:
-    - name: Install pip
-      package:
-        name: python-pip
     - name: Install boto3
       pip:
         name: boto3

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: https://github.com/cisagov/ansible-role-pip
+  name: pip

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,7 @@
 docker # Needed for molecule to work correctly
-molecule
+# Temporarily use the latest molecule from master.  The latest release
+# of molecule does not play well with ansible 2.8.  We will revert
+# this once a new release comes out.
+# molecule
+git+https://github.com/ansible/molecule.git#egg=molecule
 pre-commit

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,11 @@
 docker # Needed for molecule to work correctly
+flake8
 # Temporarily use the latest molecule from master.  The latest release
 # of molecule does not play well with ansible 2.8.  We will revert
 # this once a new release comes out.
+#
+# Also install flake8, since it appears to be missing from the
+# dependencies for the bleeding edge molecule.
 # molecule
 git+https://github.com/ansible/molecule.git#egg=molecule
 pre-commit


### PR DESCRIPTION
* Pull in upstream updates from cisagov/skeleton-ansible-role
* Leverage cisagov/ansible-role-pip instead of installing pip manually in `prepare.yml`