### PR TITLE
Support multi-account setups

### DIFF
--- a/.github-actions-pre-commit-config.yaml
+++ b/.github-actions-pre-commit-config.yaml
@@ -1,0 +1,105 @@
+---
+default_language_version:
+  # force all unspecified python hooks to run python3
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-xml
+      - id: debug-statements
+      - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
+      - id: detect-private-key
+      - id: end-of-file-fixer
+        exclude: files/(issue|motd)
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+      - id: pretty-format-json
+        args:
+          - --autofix
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.22.0
+    hooks:
+      - id: markdownlint
+        args:
+          - --config=.mdl_config.json
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.21.0
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/detailyang/pre-commit-shell
+    rev: 1.0.5
+    hooks:
+      - id: shell-lint
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-docstrings
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.1.0
+    hooks:
+      - id: pyupgrade
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.6.2
+    hooks:
+      - id: bandit
+        # Bandit complains about the use of assert() in tests
+        exclude: molecule/default/tests
+        args:
+          - --config=.bandit.yml
+  - repo: https://github.com/python/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+  - repo: https://github.com/asottile/seed-isort-config
+    rev: v2.1.0
+    hooks:
+      - id: seed-isort-config
+  - repo: https://github.com/pre-commit/mirrors-isort
+    # pick the isort version you'd like to use from
+    # https://github.com/pre-commit/mirrors-isort/releases
+    rev: v4.3.21
+    hooks:
+      - id: isort
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v4.2.0
+    hooks:
+      - id: ansible-lint
+      # files: molecule/default/playbook.yml
+  - repo: https://github.com/antonbabenko/pre-commit-terraform.git
+    rev: v1.29.0
+    hooks:
+      - id: terraform_fmt
+      # I am commenting out this hook because terraform validate
+      # cannot currently run without accessing the remote state
+      # because of the way the providers are defined in
+      # terraform/providers.tf.  This is something that may be
+      # remedied in the future.  For more information, check out these
+      # two GitHub issues:
+      # * https://github.com/hashicorp/terraform/issues/15895
+      # * https://github.com/hashicorp/terraform/issues/15811
+      #
+      # - id: terraform_validate
+  - repo: https://github.com/IamTheFij/docker-pre-commit
+    rev: v1.0.1
+    hooks:
+      - id: docker-compose-check
+  - repo: https://github.com/prettier/prettier
+    rev: 2.0.4
+    hooks:
+      - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.770
+    hooks:
+      - id: mypy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,16 @@ jobs:
       - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
       - name: Run pre-commit on all files
-        run: pre-commit run --all-files
+        # We run pre-commit here with a custom configuration that has
+        # the terraform-validate hook removed.  This is because
+        # terraform validate cannot currently run without accessing
+        # the remote state because of the way the providers are
+        # defined in terraform/providers.tf.  This is something that
+        # may be remedied in the future.  For more information, check
+        # out these two GitHub issues:
+        # * https://github.com/hashicorp/terraform/issues/15895
+        # * https://github.com/hashicorp/terraform/issues/15811
+        run: pre-commit run --all-files --config=.github-actions-pre-commit-config.yaml
   test:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ None.
 ## Role Variables ##
 
 - `package_bucket` - The name of the AWS S3 bucket containing the Nessus
-  Debian package file.  Default value: `"ncats-3rd-party-packages"`
+  Debian package file.  Default value: `"cisa-cool-third-party-production"`
 - `package_file` - The name of the Nessus Debian package file.
   Default value: `"Nessus-{{ version }}-debian6_amd64.deb"`
 - `version` - The version number of the Nessus Debian package file.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # default variable values for ansible-role-nessus
 
 # The AWS S3 bucket containing the Nessus Debian package file
-package_bucket: "ncats-3rd-party-packages"
+package_bucket: "cisa-cool-third-party-production"
 
 # The name of the Nessus Debian package file
 package_file: "Nessus-{{ version }}-debian6_amd64.deb"

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    encrypt        = true
+    key            = "ansible-role-nessus/terraform.tfstate"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+  }
+}

--- a/terraform/bucket_roles.tf
+++ b/terraform/bucket_roles.tf
@@ -1,0 +1,34 @@
+# Create the roles that allow read-only access to the particular S3
+# objects that are required by this Ansible role
+module "production_bucket_access" {
+  source = "github.com/cisagov/s3-read-role-tf-module"
+  providers = {
+    aws = aws.images-production
+  }
+
+  account_ids = [data.aws_caller_identity.current.account_id]
+  entity_name = aws_iam_user.user.name
+  role_name   = "ThirdPartyBucketRead-production-${aws_iam_user.user.name}"
+  role_tags = merge(var.tags,
+    {
+      "GitHub_Secret_Name"             = "TEST_ROLE_TO_ASSUME",
+      "GitHub_Secret_Terraform_Lookup" = "arn"
+    }
+  )
+  s3_bucket  = var.production_bucket_name
+  s3_objects = [var.nessus_package_pattern]
+}
+
+module "staging_bucket_access" {
+  source = "github.com/cisagov/s3-read-role-tf-module"
+  providers = {
+    aws = aws.images-staging
+  }
+
+  account_ids = [data.aws_caller_identity.current.account_id]
+  entity_name = aws_iam_user.user.name
+  role_name   = "ThirdPartyBucketRead-staging-${aws_iam_user.user.name}"
+  role_tags   = var.tags
+  s3_bucket   = var.staging_bucket_name
+  s3_objects  = [var.nessus_package_pattern]
+}

--- a/terraform/bucket_roles.tf
+++ b/terraform/bucket_roles.tf
@@ -8,7 +8,7 @@ module "production_bucket_access" {
 
   account_ids = [data.aws_caller_identity.current.account_id]
   entity_name = aws_iam_user.user.name
-  role_name   = "ThirdPartyBucketRead-production-${aws_iam_user.user.name}"
+  role_name   = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
   role_tags = merge(var.tags,
     {
       "GitHub_Secret_Name"             = "TEST_ROLE_TO_ASSUME",
@@ -27,7 +27,7 @@ module "staging_bucket_access" {
 
   account_ids = [data.aws_caller_identity.current.account_id]
   entity_name = aws_iam_user.user.name
-  role_name   = "ThirdPartyBucketRead-staging-${aws_iam_user.user.name}"
+  role_name   = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
   role_tags   = var.tags
   s3_bucket   = var.staging_bucket_name
   s3_objects  = [var.nessus_package_pattern]

--- a/terraform/iam_user.tf
+++ b/terraform/iam_user.tf
@@ -1,32 +1,28 @@
-locals {
-  test_user_name = "test-ansible-role-nessus"
-}
-
 # The user being created
 resource "aws_iam_user" "user" {
-  name = local.test_user_name
+  provider = aws.users
+
+  name = "test-ansible-role-nessus"
   tags = var.tags
 }
 
 # The IAM access key for the user
 resource "aws_iam_access_key" "key" {
+  provider = aws.users
+
   user = aws_iam_user.user.name
 }
 
 module "bucket_access" {
+  providers = {
+    aws = aws.images
+  }
+
   source = "github.com/cisagov/s3-read-role-tf-module"
 
   account_ids = [data.aws_caller_identity.current.account_id]
   entity_name = aws_iam_user.user.name
-  # When the user is not yet created, Terraform does not correctly
-  # pick up the user's name from aws_iam_user.user.name when passing
-  # it in on the next line, so we fall back to using
-  # local.test_user_name.
-  #
-  # It is a mystery why aws_iam_user.user.name is acceptable on the
-  # lines that sandwich this one, but not this one.
-  iam_usernames = [local.test_user_name]
-  role_name     = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
+  role_name   = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
   role_tags = merge(var.tags,
     {
       "GitHub_Secret_Name"             = "TEST_ROLE_TO_ASSUME",
@@ -35,4 +31,27 @@ module "bucket_access" {
   )
   s3_bucket  = var.bucket_name
   s3_objects = [var.nessus_package_pattern]
+}
+
+# Ensure that the test user is allowed to assume the bucket read-only
+# role
+data "aws_iam_policy_document" "assume_bucket_role" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+
+    resources = [
+      module.bucket_access.role.arn,
+    ]
+  }
+}
+resource "aws_iam_user_policy" "assume_bucket_role" {
+  provider = aws.users
+
+  policy = data.aws_iam_policy_document.assume_bucket_role.json
+  user   = aws_iam_user.user.name
 }

--- a/terraform/iam_user.tf
+++ b/terraform/iam_user.tf
@@ -13,27 +13,8 @@ resource "aws_iam_access_key" "key" {
   user = aws_iam_user.user.name
 }
 
-module "bucket_access" {
-  source = "github.com/cisagov/s3-read-role-tf-module"
-  providers = {
-    aws = aws.images
-  }
-
-  account_ids = [data.aws_caller_identity.current.account_id]
-  entity_name = aws_iam_user.user.name
-  role_name   = "ThirdPartyBucketRead-${aws_iam_user.user.name}"
-  role_tags = merge(var.tags,
-    {
-      "GitHub_Secret_Name"             = "TEST_ROLE_TO_ASSUME",
-      "GitHub_Secret_Terraform_Lookup" = "arn"
-    }
-  )
-  s3_bucket  = var.bucket_name
-  s3_objects = [var.nessus_package_pattern]
-}
-
 # Ensure that the test user is allowed to assume the bucket read-only
-# role
+# roles
 data "aws_iam_policy_document" "assume_bucket_role" {
   statement {
     effect = "Allow"
@@ -44,7 +25,8 @@ data "aws_iam_policy_document" "assume_bucket_role" {
     ]
 
     resources = [
-      module.bucket_access.role.arn,
+      module.production_bucket_access.role.arn,
+      module.staging_bucket_access.role.arn,
     ]
   }
 }

--- a/terraform/iam_user.tf
+++ b/terraform/iam_user.tf
@@ -14,11 +14,10 @@ resource "aws_iam_access_key" "key" {
 }
 
 module "bucket_access" {
+  source = "github.com/cisagov/s3-read-role-tf-module"
   providers = {
     aws = aws.images
   }
-
-  source = "github.com/cisagov/s3-read-role-tf-module"
 
   account_ids = [data.aws_caller_identity.current.account_id]
   entity_name = aws_iam_user.user.name

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# Retrieve the effective Account ID, User ID, and ARN in which
+# Terraform is authorized.  This is used to calculate the session
+# names for assumed roles.
+# ------------------------------------------------------------------------------
+data "aws_caller_identity" "current" {}
+
+# ------------------------------------------------------------------------------
+# Evaluate expressions for use throughout this configuration.
+# ------------------------------------------------------------------------------
+locals {
+  # Extract the user name of the current caller for use
+  # as assume role session names.
+  caller_user_name = split("/", data.aws_caller_identity.current.arn)[1]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,8 +1,0 @@
-# Configure AWS
-provider "aws" {
-  region = var.aws_region
-}
-
-# The AWS account ID being used
-data "aws_caller_identity" "current" {
-}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,21 @@
-output "policy" {
-  value       = module.bucket_access.policy
-  description = "The IAM policy that can read the specified objects from the specified S3 bucket."
+output "production_policy" {
+  value       = module.production_bucket_access.policy
+  description = "The IAM policy that can read the specified objects from the specified S3 production bucket."
 }
 
-output "role" {
-  value       = module.bucket_access.role
-  description = "The IAM role that can read the specified objects from the specified S3 bucket."
+output "production_role" {
+  value       = module.production_bucket_access.role
+  description = "The IAM role that can read the specified objects from the specified S3 production bucket."
+}
+
+output "staging_policy" {
+  value       = module.staging_bucket_access.policy
+  description = "The IAM policy that can read the specified objects from the specified S3 staging bucket."
+}
+
+output "staging_role" {
+  value       = module.staging_bucket_access.role
+  description = "The IAM role that can read the specified objects from the specified S3 staging bucket."
 }
 
 output "user" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "policy" {
+  value       = module.bucket_access.policy
+  description = "The IAM policy that can read the specified objects from the specified S3 bucket."
+}
+
+output "role" {
+  value       = module.bucket_access.role
+  description = "The IAM role that can read the specified objects from the specified S3 bucket."
+}
+
+output "user" {
+  value       = aws_iam_user.user
+  description = "The IAM user being created to test the cisagov/ansible-role-nessus Ansible role."
+}
+
+output "user_access_key" {
+  value       = aws_iam_access_key.key
+  description = "The access key for the IAM user being created to test the cisagov/ansible-role-nessus Ansible role."
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -26,4 +26,5 @@ output "user" {
 output "user_access_key" {
   value       = aws_iam_access_key.key
   description = "The access key for the IAM user being created to test the cisagov/ansible-role-nessus Ansible role."
+  sensitive   = true
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -6,13 +6,24 @@ provider "aws" {
   region = var.aws_region
 }
 
-# The provider used to create roles that can read objects from the COOL
-# "third-party" bucket
+# The provider used to create roles that can read objects from the
+# production COOL "third-party" bucket
 provider "aws" {
-  alias  = "images"
+  alias  = "images-production"
   region = var.aws_region
   assume_role {
-    role_arn     = data.terraform_remote_state.images.outputs.provisionthirdpartybucketreadroles_role.arn
+    role_arn     = data.terraform_remote_state.images_production.outputs.provisionthirdpartybucketreadroles_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
+# The provider used to create roles that can read objects from the
+# staging COOL "third-party" bucket
+provider "aws" {
+  alias  = "images-staging"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.images_staging.outputs.provisionthirdpartybucketreadroles_role.arn
     session_name = local.caller_user_name
   }
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,27 @@
+# This is the "default" provider that is used assume the roles in the
+# other providers.  It uses the credentials of the caller.  It is also
+# used to assume the roles required to access remote state in the
+# Terraform backend.
+provider "aws" {
+  region = var.aws_region
+}
+
+# The provider used to create roles that can read objects from an S3 bucket
+provider "aws" {
+  alias  = "images"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.images.outputs.provisionaccount_role.arn
+    session_name = local.caller_user_name
+  }
+}
+
+# The provider used to create the test user
+provider "aws" {
+  alias  = "users"
+  region = var.aws_region
+  assume_role {
+    role_arn     = data.terraform_remote_state.users.outputs.provisionaccount_role.arn
+    session_name = local.caller_user_name
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -6,12 +6,13 @@ provider "aws" {
   region = var.aws_region
 }
 
-# The provider used to create roles that can read objects from an S3 bucket
+# The provider used to create roles that can read objects from the COOL
+# "third-party" bucket
 provider "aws" {
   alias  = "images"
   region = var.aws_region
   assume_role {
-    role_arn     = data.terraform_remote_state.images.outputs.provisionaccount_role.arn
+    role_arn     = data.terraform_remote_state.images.outputs.provisionthirdpartybucketreadroles_role.arn
     session_name = local.caller_user_name
   }
 }

--- a/terraform/remote_states.tf
+++ b/terraform/remote_states.tf
@@ -1,0 +1,35 @@
+# ------------------------------------------------------------------------------
+# Retrieve state data from a Terraform backend. This allows use of the
+# root-level outputs of one or more Terraform configurations as input
+# data for this configuration.
+# ------------------------------------------------------------------------------
+
+data "terraform_remote_state" "images" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-readstate"
+    region         = "us-east-1"
+    key            = "cool-accounts/images.tfstate"
+  }
+
+  workspace = "production"
+}
+
+data "terraform_remote_state" "users" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-readstate"
+    region         = "us-east-1"
+    key            = "cool-accounts/users.tfstate"
+  }
+
+  workspace = "production"
+}

--- a/terraform/remote_states.tf
+++ b/terraform/remote_states.tf
@@ -4,7 +4,7 @@
 # data for this configuration.
 # ------------------------------------------------------------------------------
 
-data "terraform_remote_state" "images" {
+data "terraform_remote_state" "images_production" {
   backend = "s3"
 
   config = {
@@ -17,6 +17,21 @@ data "terraform_remote_state" "images" {
   }
 
   workspace = "production"
+}
+
+data "terraform_remote_state" "images_staging" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-readstate"
+    region         = "us-east-1"
+    key            = "cool-accounts/images.tfstate"
+  }
+
+  workspace = "staging"
 }
 
 data "terraform_remote_state" "users" {

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,9 +1,0 @@
-terraform {
-  backend "s3" {
-    encrypt        = true
-    bucket         = "ncats-terraform-state-storage"
-    dynamodb_table = "terraform-state-lock"
-    region         = "us-east-1"
-    key            = "ansible-role-nessus/terraform.tfstate"
-  }
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,9 +9,15 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-variable "bucket_name" {
-  description = "The name of the bucket that the user should be allowed to read from."
+variable "production_bucket_name" {
+  description = "The name of the S3 bucket that where the production Nessus package lives."
   default     = "cisa-cool-third-party-production"
+}
+
+variable "staging_bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket that where the staging Nessus package lives."
+  default     = "cisa-cool-third-party-staging"
 }
 
 variable "nessus_package_pattern" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,13 +10,13 @@ variable "aws_region" {
 }
 
 variable "production_bucket_name" {
-  description = "The name of the S3 bucket that where the production Nessus package lives."
+  description = "The name of the S3 bucket where the production Nessus package lives."
   default     = "cisa-cool-third-party-production"
 }
 
 variable "staging_bucket_name" {
   type        = string
-  description = "The name of the S3 bucket that where the staging Nessus package lives."
+  description = "The name of the S3 bucket where the staging Nessus package lives."
   default     = "cisa-cool-third-party-staging"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,7 +11,7 @@ variable "aws_region" {
 
 variable "bucket_name" {
   description = "The name of the bucket that the user should be allowed to read from."
-  default     = "ncats-3rd-party-packages"
+  default     = "cisa-cool-third-party-production"
 }
 
 variable "nessus_package_pattern" {


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR modifies the test user Terraform to support a multi-account setup (like the COOL), where the test user may not reside in the same AWS account as the S3 bucket that contains the Nessus package.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context
We want to standardize this Ansible role (and all of our roles) so that they work properly within the COOL environment, and still remain functional in single-account setups (like our Production CyHy account). 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
All automated tests pass.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
