### PR TITLE
Modify role to install the latest 8.x version of Nessus

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-# default variable values for ansible-role-nessus
-
 # The AWS S3 bucket containing the Nessus Debian package file
 package_bucket: "cisa-cool-third-party-production"
 
@@ -8,4 +6,4 @@ package_bucket: "cisa-cool-third-party-production"
 package_file: "Nessus-{{ version }}-debian6_amd64.deb"
 
 # The version number of the Nessus Debian package file
-version: "8.7.1"
+version: "8.15.4"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,4 @@ package_bucket: "cisa-cool-third-party-production"
 package_file: "Nessus-{{ version }}-debian6_amd64.deb"
 
 # The version number of the Nessus Debian package file
-version: "8.15.4"
+version: "8.15.5"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,7 +18,13 @@ def test_packages(host, pkg):
     assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("f", ["/tmp/Nessus-8.7.1-debian6_amd64.deb"])
+def test_nessus_version(host):
+    """Check that the correct version of Nessus was installed."""
+    cmd = host.run("/opt/nessus/sbin/nessusd --version")
+    assert " 8.15.4 " in cmd.stdout
+
+
+@pytest.mark.parametrize("f", ["/tmp/Nessus-8.15.4-debian6_amd64.deb"])
 def test_tmp_files(host, f):
     """Test that the temporary files were deleted."""
     assert not host.file(f).exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,7 +21,7 @@ def test_packages(host, pkg):
 def test_nessus_version(host):
     """Check that the correct version of Nessus was installed."""
     cmd = host.run("/opt/nessus/sbin/nessusd --version")
-    assert " 8.15.4 " in cmd.stdout
+    assert " 8.15.5 " in cmd.stdout
 
 
 @pytest.mark.parametrize("f", ["/tmp/Nessus-8.15.4-debian6_amd64.deb"])


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible role to install the latest 8.x version of Nessus.

## 💭 Motivation and context ##

The latest 8.x version of Ansible was tested as part of the latest CyHy deployment, so we may as well use it in the COOL too.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.