### PR TITLE
Add the S3 bucket policies to the TF outputs

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,9 +4,19 @@ output "access_key" {
   sensitive   = true
 }
 
+output "production_bucket_policy" {
+  value       = module.production_bucket_access.policy
+  description = "The IAM policy that allows the CI user to read certain objects in the production third-party S3 bucket."
+}
+
 output "production_role" {
   value       = module.user.production_role
   description = "The IAM role that the CI user can assume to read SSM parameters in the production account."
+}
+
+output "staging_bucket_policy" {
+  value       = module.staging_bucket_access.policy
+  description = "The IAM policy that allows the CI user to read certain objects in the staging third-party S3 bucket."
 }
 
 output "staging_role" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the read-only S3 bucket policies to the TF outputs.

## 💭 Motivation and context ##

These policies are required by the Terraform code in [cisagov/nessus-packer](https://github.com/cisagov/nessus-packer).  I added this change locally, but it seems I neglected to create a pull request for it.

## 🧪 Testing ##

All automated testing passes, and this change is already live.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.