### PR TITLE
Support installation of recent versions of Nessus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
       matrix:
         scenario:
           - default
+          - latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/default/tests
+        exclude: molecule/(default|latest)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
+| architecture | The processor architecture for which Nessus is to be installed. | `amd64` | No |
+| distribution | The Linux distribution on which Nessus is to be installed. | `amd64` | No |
 | package_bucket | The name of the AWS S3 bucket containing the Nessus Debian package file. | `cisa-cool-third-party-production` | No |
-| package_file | The name of the Nessus Debian package file. | `Nessus-{{ version }}-debian6_amd64.deb` | No |
-| version | The version number of the Nessus Debian package file. | `8.7.1` | No |
+| package_file | The name of the Nessus Debian package file. | `Nessus-{{ version }}-{{distribution}}_{{architecture}}.deb` | No |
+| version | The version number of the Nessus Debian package file. | `8.15.5` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| architecture | The processor architecture for which Nessus is to be installed. | `amd64` | No |
-| distribution | The Linux distribution on which Nessus is to be installed. | `debian6` | No |
-| format | The format/file extension of the desired Nessus package file. | `deb` | No |
+| architecture | The processor architecture for which Nessus is to be installed, as specified in the Nessus package filename. | `amd64` | No |
+| distribution | The Linux distribution on which Nessus is to be installed, as specified in the Nessus package filename. | `debian6` | No |
+| format | The format/file extension of the desired Nessus package file (e.g. deb, rpm). | `deb` | No |
 | package_bucket | The name of the AWS S3 bucket containing the Nessus package file. | `cisa-cool-third-party-production` | No |
 | package_file | The name of the Nessus package file. | `Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}` | No |
-| version | The version number of the Nessus package file. | `8.15.5` | No |
+| version | The version number of the Nessus package file, as specified in the Nessus package filename. | `8.15.5` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| architecture | The processor architecture for which Nessus is to be installed, as specified in the Nessus package filename. | `amd64` | No |
 | distribution | The Linux distribution on which Nessus is to be installed, as specified in the Nessus package filename. | `debian6` | No |
-| format | The format/file extension of the desired Nessus package file (e.g. deb, rpm). | `deb` | No |
 | package_bucket | The name of the AWS S3 bucket containing the Nessus package file. | `cisa-cool-third-party-production` | No |
 | package_file | The name of the Nessus package file. | `Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}` | No |
 | version | The version number of the Nessus package file, as specified in the Nessus package filename. | `8.15.5` | No |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ None.
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | architecture | The processor architecture for which Nessus is to be installed. | `amd64` | No |
-| distribution | The Linux distribution on which Nessus is to be installed. | `amd64` | No |
+| distribution | The Linux distribution on which Nessus is to be installed. | `debian6` | No |
 | format | The format/file extension of the desired Nessus package file. | `deb` | No |
 | package_bucket | The name of the AWS S3 bucket containing the Nessus package file. | `cisa-cool-third-party-production` | No |
 | package_file | The name of the Nessus package file. | `Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}` | No |

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ None.
 |----------|-------------|---------|----------|
 | architecture | The processor architecture for which Nessus is to be installed. | `amd64` | No |
 | distribution | The Linux distribution on which Nessus is to be installed. | `amd64` | No |
-| package_bucket | The name of the AWS S3 bucket containing the Nessus Debian package file. | `cisa-cool-third-party-production` | No |
-| package_file | The name of the Nessus Debian package file. | `Nessus-{{ version }}-{{distribution}}_{{architecture}}.deb` | No |
-| version | The version number of the Nessus Debian package file. | `8.15.5` | No |
+| format | The format/file extension of the desired Nessus package file. | `deb` | No |
+| package_bucket | The name of the AWS S3 bucket containing the Nessus package file. | `cisa-cool-third-party-production` | No |
+| package_file | The name of the Nessus package file. | `Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}` | No |
+| version | The version number of the Nessus package file. | `8.15.5` | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| distribution | The Linux distribution on which Nessus is to be installed, as specified in the Nessus package filename. | `debian6` | No |
 | package_bucket | The name of the AWS S3 bucket containing the Nessus package file. | `cisa-cool-third-party-production` | No |
-| package_file | The name of the Nessus package file. | `Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}` | No |
 | version | The version number of the Nessus package file, as specified in the Nessus package filename. | `8.15.5` | No |
 
 ## Dependencies ##

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,20 +1,29 @@
 ---
-# The processor architecture for which Nessus is to be installed, as
-# specified in the Nessus package filename
-architecture: amd64
+# A dictionary whose keys are values of the Ansible fact
+# ansible_architecture and whose values are processor architecture for
+# which Nessus is to be installed, as specified in the Nessus package
+# filename
+architectures:
+  arm64: aarch64
+  i386: i386
+  x86_64: amd64
 
 # The Linux distribution for which Nessus is to be installed, as
 # specified in the Nessus package filename
 distribution: debian6
 
-# The format/file extension of the Nessus package file (e.g. deb, rpm)
-format: deb
+# A dictionary whose keys are values of the Ansible fact
+# ansible_os_family and whose values are the format/file extension of
+# the Nessus package file (e.g. deb, rpm)
+formats:
+  Debian: deb
+  RedHat: rpm
 
 # The name of the AWS S3 bucket containing the Nessus package file
 package_bucket: cisa-cool-third-party-production
 
 # The name of the Nessus package file
-package_file: Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}
+package_file: Nessus-{{ version }}-{{ distribution }}_{{ architectures[ansible_architecture] }}.{{ formats[ansible_os_family] }}
 
 # The version number of the Nessus package file, as specified in the
 # Nessus package filename

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,13 @@
 ---
-# The processor architecture for which Nessus is to be installed
+# The processor architecture for which Nessus is to be installed, as
+# specified in the Nessus package filename
 architecture: amd64
 
-# The Linux distribution on which Nessus is to be installed
+# The Linux distribution for which Nessus is to be installed, as
+# specified in the Nessus package filename
 distribution: debian6
 
-# The format/file extension of the desired Nessus package file
-# (e.g. deb, rpm)
+# The format/file extension of the Nessus package file (e.g. deb, rpm)
 format: deb
 
 # The name of the AWS S3 bucket containing the Nessus package file
@@ -15,5 +16,6 @@ package_bucket: cisa-cool-third-party-production
 # The name of the Nessus package file
 package_file: Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}
 
-# The version number of the Nessus package file
+# The version number of the Nessus package file, as specified in the
+# Nessus package filename
 version: 8.15.5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,15 @@ architectures:
 distribution: debian6
 
 # A dictionary whose keys are values of the Ansible fact
+# ansible_os_family and whose values are the string used to separate
+# the distribution from the architecture in the Nessus package
+# filename.  For some reason the Nessus package filenames use periods
+# for RedHat-based distros and underscores for Debian-based distros.
+distribution_arch_separator:
+  Debian: _
+  RedHat: .
+
+# A dictionary whose keys are values of the Ansible fact
 # ansible_os_family and whose values are the format/file extension of
 # the Nessus package file (e.g. deb, rpm)
 formats:
@@ -23,7 +32,7 @@ formats:
 package_bucket: cisa-cool-third-party-production
 
 # The name of the Nessus package file
-package_file: Nessus-{{ version }}-{{ distribution }}_{{ architectures[ansible_architecture] }}.{{ formats[ansible_os_family] }}
+package_file: Nessus-{{ version }}-{{ distribution }}{{ distribution_arch_separator[ansible_os_family] }}{{ architectures[ansible_architecture] }}.{{ formats[ansible_os_family] }}
 
 # The version number of the Nessus package file, as specified in the
 # Nessus package filename

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,15 @@ architecture: amd64
 # The Linux distribution on which Nessus is to be installed
 distribution: debian6
 
-# The AWS S3 bucket containing the Nessus Debian package file
+# The format/file extension of the desired Nessus package file
+# (e.g. deb, rpm)
+format: deb
+
+# The name of the AWS S3 bucket containing the Nessus package file
 package_bucket: cisa-cool-third-party-production
 
-# The name of the Nessus Debian package file
-package_file: Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.deb
+# The name of the Nessus package file
+package_file: Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.{{ format }}
 
-# The version number of the Nessus Debian package file
+# The version number of the Nessus package file
 version: 8.15.5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,38 +1,10 @@
 ---
-# A dictionary whose keys are values of the Ansible fact
-# ansible_architecture and whose values are processor architecture for
-# which Nessus is to be installed, as specified in the Nessus package
-# filename
-architectures:
-  arm64: aarch64
-  i386: i386
-  x86_64: amd64
-
 # The Linux distribution for which Nessus is to be installed, as
 # specified in the Nessus package filename
 distribution: debian6
 
-# A dictionary whose keys are values of the Ansible fact
-# ansible_os_family and whose values are the string used to separate
-# the distribution from the architecture in the Nessus package
-# filename.  For some reason the Nessus package filenames use periods
-# for RedHat-based distros and underscores for Debian-based distros.
-distribution_arch_separator:
-  Debian: _
-  RedHat: .
-
-# A dictionary whose keys are values of the Ansible fact
-# ansible_os_family and whose values are the format/file extension of
-# the Nessus package file (e.g. deb, rpm)
-formats:
-  Debian: deb
-  RedHat: rpm
-
 # The name of the AWS S3 bucket containing the Nessus package file
 package_bucket: cisa-cool-third-party-production
-
-# The name of the Nessus package file
-package_file: Nessus-{{ version }}-{{ distribution }}{{ distribution_arch_separator[ansible_os_family] }}{{ architectures[ansible_architecture] }}.{{ formats[ansible_os_family] }}
 
 # The version number of the Nessus package file, as specified in the
 # Nessus package filename

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,15 @@
 ---
+# The processor architecture for which Nessus is to be installed
+architecture: amd64
+
+# The Linux distribution on which Nessus is to be installed
+distribution: debian6
+
 # The AWS S3 bucket containing the Nessus Debian package file
-package_bucket: "cisa-cool-third-party-production"
+package_bucket: cisa-cool-third-party-production
 
 # The name of the Nessus Debian package file
-package_file: "Nessus-{{ version }}-debian6_amd64.deb"
+package_file: Nessus-{{ version }}-{{ distribution }}_{{ architecture }}.deb
 
 # The version number of the Nessus Debian package file
-version: "8.15.5"
+version: 8.15.5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,4 @@
 ---
-# The Linux distribution for which Nessus is to be installed, as
-# specified in the Nessus package filename
-distribution: debian6
-
 # The name of the AWS S3 bucket containing the Nessus package file
 package_bucket: cisa-cool-third-party-production
 

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -16,6 +16,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  - name: amazonlinux2
+    image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2
@@ -27,6 +29,10 @@ platforms:
     image: debian:bookworm-slim
   - name: kali
     image: kalilinux/kali-rolling
+  - name: fedora34
+    image: fedora:34
+  - name: fedora35
+    image: fedora:35
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -11,6 +11,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
 ).get_hosts("all")
 
+# The architecture as listed in the Nessus package filename
+arch = "amd64"
+# The Linux distribution as listed in the Nessus package filename
+distro = "debian6"
+# The format/file extension of the Nessus package
+fmt = "deb"
+# The version of Nessus that should be installed
+version = "8.15.5"
+
 
 @pytest.mark.parametrize("pkg", ["expect", "jq", "nessus"])
 def test_packages(host, pkg):
@@ -21,10 +30,10 @@ def test_packages(host, pkg):
 def test_nessus_version(host):
     """Check that the correct version of Nessus was installed."""
     cmd = host.run("/opt/nessus/sbin/nessusd --version")
-    assert " 8.15.5 " in cmd.stdout
+    assert f" {version} " in cmd.stdout
 
 
-@pytest.mark.parametrize("f", ["/tmp/Nessus-8.15.4-debian6_amd64.deb"])
+@pytest.mark.parametrize("f", [f"/tmp/Nessus-{version}-{distro}_{arch}.{fmt}"])
 def test_tmp_files(host, f):
     """Test that the temporary files were deleted."""
     assert not host.file(f).exists

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,5 +1,8 @@
 """Module containing the tests for the default scenario."""
 
+# TODO: See cisagov/ansible-role-nessus#22 for some thoughts on
+# sharing the same test code among the different Molecule scenarios.
+
 # Standard Python Libraries
 import os
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -7,36 +7,29 @@
 import os
 
 # Third-Party Libraries
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
 ).get_hosts("all")
 
-# The architecture as listed in the Nessus package filename
-arch = "amd64"
-# The Linux distribution as listed in the Nessus package filename
-distro = "debian6"
-# The format/file extension of the Nessus package
-fmt = "deb"
 # The version of Nessus that should be installed
 version = "8.15.5"
 
 
-@pytest.mark.parametrize("pkg", ["expect", "jq", "nessus"])
-def test_packages(host, pkg):
+def test_packages(host):
     """Test that the appropriate packages were installed."""
-    assert host.package(pkg).is_installed
+    debian_packages = ["expect", "jq", "nessus"]
+    redhat_packages = ["expect", "jq", "Nessus"]
+    if host.system_info.distribution in ["debian", "kali", "ubuntu"]:
+        assert all([host.package(pkg).is_installed for pkg in debian_packages])
+    elif host.system_info.distribution in ["amzn", "fedora"]:
+        assert all([host.package(pkg).is_installed for pkg in redhat_packages])
+    else:
+        assert False, f"Unknown distribution {host.system_info.distribution}"
 
 
 def test_nessus_version(host):
     """Check that the correct version of Nessus was installed."""
     cmd = host.run("/opt/nessus/sbin/nessusd --version")
     assert f" {version} " in cmd.stdout
-
-
-@pytest.mark.parametrize("f", [f"/tmp/Nessus-{version}-{distro}_{arch}.{fmt}"])
-def test_tmp_files(host, f):
-    """Test that the temporary files were deleted."""
-    assert not host.file(f).exists

--- a/molecule/latest/INSTALL.rst
+++ b/molecule/latest/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/latest/converge.yml
+++ b/molecule/latest/converge.yml
@@ -6,5 +6,4 @@
       ansible.builtin.include_role:
         name: ansible-role-nessus
       vars:
-        distribution: "debian9"
         version: "10.3.0"

--- a/molecule/latest/converge.yml
+++ b/molecule/latest/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-nessus
+      ansible.builtin.include_role:
+        name: ansible-role-nessus
+      vars:
+        distribution: "debian9"
+        version: "10.3.0"

--- a/molecule/latest/molecule-no-systemd.yml
+++ b/molecule/latest/molecule-no-systemd.yml
@@ -1,0 +1,68 @@
+---
+# This molecule configuration file is suitable for testing Ansible
+# roles that _do not_ require SystemD.  If your Ansible role _does_
+# require SystemD then you should use molecule-with-systemd.yml
+# instead.
+#
+# Note that the molecule configuration file that is symlinked to
+# molecule.yml is the one that will be used.
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: debian9
+    image: debian:stretch-slim
+    dockerfile: Dockerfile_debian_9.j2
+  - name: debian10
+    image: debian:buster-slim
+  - name: debian11
+    image: debian:bullseye-slim
+  - name: debian12
+    image: debian:bookworm-slim
+  - name: kali
+    image: kalilinux/kali-rolling
+  - name: ubuntu18
+    image: ubuntu:bionic
+  - name: ubuntu20
+    image: ubuntu:focal
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      debian9:
+        # auto_legacy is still the default behavior until Ansible 2.12
+        # is released, but Molecule overrides this and forces the use
+        # of auto.
+        #
+        # In auto_legacy mode Ansible will prefer the /usr/bin/python
+        # interpreter if it exists, while in auto mode it will prefer
+        # the Python interpreter specified in an internal map.  In
+        # most cases we only have Python3 installed, and the internal
+        # map specifies /usr/bin/python3, so it is immaterial whether
+        # we use auto_legacy or auto.
+        #
+        # The one place where it _does_ matter is our Debian9 AKA CyHy
+        # instances.  Here the /usr/bin/python _and_ /usr/bin/python3
+        # interpreters are both installed.  In Ansible 2.10 a Debian
+        # entry was added to the internal map, so now auto_legacy
+        # selects the /usr/bin/python interpreter while auto selects
+        # the /usr/bin/python3 interpreter.  We want to maintain the
+        # auto_legacy behavior in this case since CyHy is still
+        # Python2.
+        #
+        # See:
+        # * https://github.com/ansible-community/molecule/blob/3.0.8/molecule/provisioner/ansible.py#L389
+        # * https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/config/base.yml#L1492-L1542
+        # * https://github.com/ansible/ansible/blob/v2.10.1/lib/ansible/executor/interpreter_discovery.py
+        ansible_python_interpreter: auto_legacy
+scenario:
+  name: latest
+verifier:
+  name: testinfra

--- a/molecule/latest/molecule-no-systemd.yml
+++ b/molecule/latest/molecule-no-systemd.yml
@@ -16,6 +16,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
+  - name: amazonlinux2
+    image: amazonlinux:2
   - name: debian9
     image: debian:stretch-slim
     dockerfile: Dockerfile_debian_9.j2
@@ -27,6 +29,10 @@ platforms:
     image: debian:bookworm-slim
   - name: kali
     image: kalilinux/kali-rolling
+  - name: fedora34
+    image: fedora:34
+  - name: fedora35
+    image: fedora:35
   - name: ubuntu18
     image: ubuntu:bionic
   - name: ubuntu20

--- a/molecule/latest/molecule-with-systemd.yml
+++ b/molecule/latest/molecule-with-systemd.yml
@@ -1,0 +1,1 @@
+../default/molecule-with-systemd.yml

--- a/molecule/latest/molecule.yml
+++ b/molecule/latest/molecule.yml
@@ -1,0 +1,1 @@
+molecule-no-systemd.yml

--- a/molecule/latest/prepare.yml
+++ b/molecule/latest/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/latest/python.yml
+++ b/molecule/latest/python.yml
@@ -1,0 +1,1 @@
+../default/python.yml

--- a/molecule/latest/requirements.yml
+++ b/molecule/latest/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/latest/tests/test_latest.py
+++ b/molecule/latest/tests/test_latest.py
@@ -1,5 +1,8 @@
 """Module containing the tests for the latest scenario."""
 
+# TODO: See cisagov/ansible-role-nessus#22 for some thoughts on
+# sharing the same test code among the different Molecule scenarios.
+
 # Standard Python Libraries
 import os
 

--- a/molecule/latest/tests/test_latest.py
+++ b/molecule/latest/tests/test_latest.py
@@ -1,0 +1,30 @@
+"""Module containing the tests for the latest scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+@pytest.mark.parametrize("pkg", ["expect", "jq", "nessus"])
+def test_packages(host, pkg):
+    """Test that the appropriate packages were installed."""
+    assert host.package(pkg).is_installed
+
+
+def test_nessus_version(host):
+    """Check that the correct version of Nessus was installed."""
+    cmd = host.run("/opt/nessus/sbin/nessusd --version")
+    assert " 10.3.0 " in cmd.stdout
+
+
+@pytest.mark.parametrize("f", ["/tmp/Nessus-10.3.0-debian9_amd64.deb"])
+def test_tmp_files(host, f):
+    """Test that the temporary files were deleted."""
+    assert not host.file(f).exists

--- a/molecule/latest/tests/test_latest.py
+++ b/molecule/latest/tests/test_latest.py
@@ -11,6 +11,15 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ["MOLECULE_INVENTORY_FILE"]
 ).get_hosts("all")
 
+# The architecture as listed in the Nessus package filename
+arch = "amd64"
+# The Linux distribution as listed in the Nessus package filename
+distro = "debian9"
+# The format/file extension of the Nessus package
+fmt = "deb"
+# The version of Nessus that should be installed
+version = "10.3.0"
+
 
 @pytest.mark.parametrize("pkg", ["expect", "jq", "nessus"])
 def test_packages(host, pkg):
@@ -21,10 +30,10 @@ def test_packages(host, pkg):
 def test_nessus_version(host):
     """Check that the correct version of Nessus was installed."""
     cmd = host.run("/opt/nessus/sbin/nessusd --version")
-    assert " 10.3.0 " in cmd.stdout
+    assert f" {version} " in cmd.stdout
 
 
-@pytest.mark.parametrize("f", ["/tmp/Nessus-10.3.0-debian9_amd64.deb"])
+@pytest.mark.parametrize("f", [f"/tmp/Nessus-{version}-{distro}_{arch}.{fmt}"])
 def test_tmp_files(host, f):
     """Test that the temporary files were deleted."""
     assert not host.file(f).exists

--- a/molecule/latest/upgrade.yml
+++ b/molecule/latest/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,6 @@
 ---
-- name: Check if Nessus is installed
-  ansible.builtin.command: |
-    dpkg-query --show --showformat='${db:Status-Status}|${Version}\n' nessus
-  register: dpkg_query_result
-  ignore_errors: yes
-  changed_when: false
+- name: Gather package facts
+  ansible.builtin.package_facts:
 
 - name: Install Nessus
   block:
@@ -17,7 +13,7 @@
       become: no
       delegate_to: localhost
 
-    - name: Copy local Nessus package (.deb) to remote side
+    - name: Copy local Nessus package to remote side
       ansible.builtin.copy:
         src: /tmp/{{ package_file }}
         dest: /tmp/{{ package_file }}
@@ -28,7 +24,7 @@
         deb: /tmp/{{ package_file }}
         state: present
 
-    - name: Delete Nessus package (.deb) on remote side
+    - name: Delete Nessus package on remote side
       ansible.builtin.file:
         path: /tmp/{{ package_file }}
         state: absent
@@ -39,10 +35,12 @@
         state: absent
       become: no
       delegate_to: localhost
-  # Only run this block is Nessus is installed and is the correct
-  # version
+  # Only run this block if Nessus is not installed or is not the
+  # correct version
   when: |
-    not dpkg_query_result.stdout is search('installed|%s' | format(version)) | bool
+    ansible_facts.packages.nessus is not defined
+    or ansible_facts.packages.nessus[0].version is not defined
+    or not ansible_facts.packages.nessus[0].version is search(version) | bool
 
 - name: Load var file with package name(s) based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,9 +41,26 @@
             mode: 0644
 
         - name: Install specified Nessus version
-          ansible.builtin.apt:
-            deb: /tmp/{{ package_file }}
-            state: present
+          block:
+            - name: Install apt package
+              ansible.builtin.apt:
+                deb: /tmp/{{ package_file }}
+                state: present
+              when: ansible_pkg_mgr == "apt"
+            - name: Install dnf package
+              ansible.builtin.dnf:
+                # If we downloaded the RPM signing key from Tenable
+                # then we'd be downloading it from the same website as
+                # the package anyway.
+                disable_gpg_check: yes
+                name: /tmp/{{ package_file }}
+                state: present
+              when: ansible_pkg_mgr == "dnf"
+            - name: Install yum package
+              ansible.builtin.yum:
+                name: /tmp/{{ package_file }}
+                state: present
+              when: ansible_pkg_mgr == "yum"
 
         - name: Delete Nessus package on remote side
           ansible.builtin.file:
@@ -59,11 +76,15 @@
       vars:
         package_file: "{{ keys.s3_keys | select('search', package_file_regex) | first }}"
   # Only run this block if Nessus is not installed or is not the
-  # correct version
+  # correct version.  Note that the Nessus package name can be
+  # capitalized or not capitalized.
   when: |
-    ansible_facts.packages.nessus is not defined
-    or ansible_facts.packages.nessus[0].version is not defined
-    or not ansible_facts.packages.nessus[0].version is search(version) | bool
+    (ansible_facts.packages.nessus is not defined
+     or ansible_facts.packages.nessus[0].version is not defined
+     or not ansible_facts.packages.nessus[0].version is search(version) | bool) and
+    (ansible_facts.packages.Nessus is not defined
+     or ansible_facts.packages.Nessus[0].version is not defined
+     or not ansible_facts.packages.Nessus[0].version is search(version) | bool)
 
 # "expect" and "jq" are used downstream to automate creation of Nessus users
 - name: Install expect and jq packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Load var file based on the OS type
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - "{{ role_path }}/vars"
+
 - name: Gather package facts
   ansible.builtin.package_facts:
 
@@ -41,17 +52,6 @@
     ansible_facts.packages.nessus is not defined
     or ansible_facts.packages.nessus[0].version is not defined
     or not ansible_facts.packages.nessus[0].version is search(version) | bool
-
-- name: Load var file with package name(s) based on the OS type
-  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
-  vars:
-    params:
-      files:
-        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
-      paths:
-        - "{{ role_path }}/vars"
 
 # "expect" and "jq" are used downstream to automate creation of Nessus users
 - name: Install expect and jq packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,37 +15,49 @@
 
 - name: Install Nessus
   block:
-    - name: Fetch specified Nessus package from S3
+    - name: Fetch list of keys in bucket
       ansible.builtin.aws_s3:
         bucket: "{{ package_bucket }}"
-        object: "{{ package_file }}"
-        dest: /tmp/{{ package_file }}
-        mode: get
+        mode: list
       become: no
       delegate_to: localhost
+      register: keys
 
-    - name: Copy local Nessus package to remote side
-      ansible.builtin.copy:
-        src: /tmp/{{ package_file }}
-        dest: /tmp/{{ package_file }}
-        mode: 0644
+    - name: Install Nessus package file
+      block:
+        - name: Fetch specified Nessus package from S3
+          ansible.builtin.aws_s3:
+            bucket: "{{ package_bucket }}"
+            object: "{{ package_file }}"
+            dest: /tmp/{{ package_file }}
+            mode: get
+          become: no
+          delegate_to: localhost
 
-    - name: Install specified Nessus version
-      ansible.builtin.apt:
-        deb: /tmp/{{ package_file }}
-        state: present
+        - name: Copy local Nessus package to remote side
+          ansible.builtin.copy:
+            src: /tmp/{{ package_file }}
+            dest: /tmp/{{ package_file }}
+            mode: 0644
 
-    - name: Delete Nessus package on remote side
-      ansible.builtin.file:
-        path: /tmp/{{ package_file }}
-        state: absent
+        - name: Install specified Nessus version
+          ansible.builtin.apt:
+            deb: /tmp/{{ package_file }}
+            state: present
 
-    - name: Delete local copy of Nessus package
-      ansible.builtin.file:
-        path: /tmp/{{ package_file }}
-        state: absent
-      become: no
-      delegate_to: localhost
+        - name: Delete Nessus package on remote side
+          ansible.builtin.file:
+            path: /tmp/{{ package_file }}
+            state: absent
+
+        - name: Delete local copy of Nessus package
+          ansible.builtin.file:
+            path: /tmp/{{ package_file }}
+            state: absent
+          become: no
+          delegate_to: localhost
+      vars:
+        package_file: "{{ keys.s3_keys | select('search', package_file_regex) | first }}"
   # Only run this block if Nessus is not installed or is not the
   # correct version
   when: |

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,7 +23,7 @@ variable "staging_bucket_name" {
 
 variable "nessus_package_pattern" {
   description = "The pattern that matches the name of Nessus package objects in the S3 bucket specified by the bucket_name variable."
-  default     = "Nessus-*-debian6_amd64.deb"
+  default     = "Nessus-*-*_*.deb"
 }
 
 variable "tags" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,7 +23,7 @@ variable "staging_bucket_name" {
 
 variable "nessus_package_pattern" {
   description = "The pattern that matches the name of Nessus package objects in the S3 bucket specified by the bucket_name variable."
-  default     = "Nessus-*-*_*.deb"
+  default     = "Nessus-*.*"
 }
 
 variable "tags" {

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,23 @@
+---
+# A dictionary whose keys are values of the Ansible fact
+# ansible_architecture and whose values are processor architecture for
+# which Nessus is to be installed, as specified in the Nessus package
+# filename
+architectures:
+  arm64: aarch64
+  i386: i386
+  x86_64: x86_64
+
+# The format/file extension of the Nessus package file (e.g. deb, rpm)
+format: rpm
+
+# A regex that will match the name of the Nessus package file that
+# should be installed.  Note that we force the distribution name here,
+# because what Nessus uses ("amzn") does not match what Ansible uses
+# ("Amazon").
+package_file_regex: "Nessus-{{ version }}-amzn[0-9]*\\.{{ architectures[ansible_architecture] }}\\.{{ format }}"
+
+# The packages to install
+package_names:
+  - expect
+  - jq

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,8 +11,9 @@ architectures:
 # The format/file extension of the Nessus package file (e.g. deb, rpm)
 format: deb
 
-# The name of the Nessus package file
-package_file_regex: "Nessus-{{ version }}-{{ ansible_distribution | lower }}[0-9]*_{{ architectures[ansible_architecture] }}.{{ format }}"
+# A regex that will match the name of the Nessus package file that
+# should be installed
+package_file_regex: "Nessus-{{ version }}-{{ ansible_distribution | lower }}[0-9]*_{{ architectures[ansible_architecture] }}\\.{{ format }}"
 
 # The packages to install
 package_names:

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,0 +1,23 @@
+---
+# A dictionary whose keys are values of the Ansible fact
+# ansible_architecture and whose values are processor architecture for
+# which Nessus is to be installed, as specified in the Nessus package
+# filename
+architectures:
+  arm64: aarch64
+  i386: i386
+  x86_64: x86_64
+
+# The format/file extension of the Nessus package file (e.g. deb, rpm)
+format: rpm
+
+# A regex that will match the name of the Nessus package file that
+# should be installed.  Note that we force the distribution name here,
+# because what Nessus uses ("fc") does not match what Ansible uses
+# ("Fedora").
+package_file_regex: "Nessus-{{ version }}-fc[0-9]*\\.{{ architectures[ansible_architecture] }}\\.{{ format }}"
+
+# The packages to install
+package_names:
+  - expect
+  - jq

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -11,8 +11,9 @@ architectures:
 # The format/file extension of the Nessus package file (e.g. deb, rpm)
 format: deb
 
-# The name of the Nessus package file
-package_file_regex: "Nessus-{{ version }}-{{ ansible_distribution | lower }}[0-9]*_{{ architectures[ansible_architecture] }}.{{ format }}"
+# The name of the Nessus package file.  Note that we force the use of
+# the Debian packages for Kali, since it is based on Debian testing.
+package_file_regex: "Nessus-{{ version }}-debian[0-9]*_{{ architectures[ansible_architecture] }}.{{ format }}"
 
 # The packages to install
 package_names:

--- a/vars/Kali.yml
+++ b/vars/Kali.yml
@@ -11,9 +11,10 @@ architectures:
 # The format/file extension of the Nessus package file (e.g. deb, rpm)
 format: deb
 
-# The name of the Nessus package file.  Note that we force the use of
-# the Debian packages for Kali, since it is based on Debian testing.
-package_file_regex: "Nessus-{{ version }}-debian[0-9]*_{{ architectures[ansible_architecture] }}.{{ format }}"
+# A regex that will match the name of the Nessus package file that
+# should be installed.  Note that we force the use of the Debian
+# packages for Kali, since it is based on Debian testing.
+package_file_regex: "Nessus-{{ version }}-debian[0-9]*_{{ architectures[ansible_architecture] }}\\.{{ format }}"
 
 # The packages to install
 package_names:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,1 +1,0 @@
-Debian.yml

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -11,8 +11,9 @@ architectures:
 # The format/file extension of the Nessus package file (e.g. deb, rpm)
 format: rpm
 
-# The name of the Nessus package file
-package_file: Nessus-{{ version }}-{{ distribution }}.{{ architectures[ansible_architecture] }}.{{ format }}
+# A regex that will match the name of the Nessus package file that
+# should be installed
+package_file_regex: "Nessus-{{ version }}-{{ ansible_distribution | lower }}[0-9]*\\.{{ architectures[ansible_architecture] }}\\.{{ format }}"
 
 # The packages to install
 package_names:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,13 +6,13 @@
 architectures:
   arm64: aarch64
   i386: i386
-  x86_64: amd64
+  x86_64: x86_64
 
 # The format/file extension of the Nessus package file (e.g. deb, rpm)
-format: deb
+format: rpm
 
 # The name of the Nessus package file
-package_file: Nessus-{{ version }}-{{ distribution }}_{{ architectures[ansible_architecture] }}.{{ format }}
+package_file: Nessus-{{ version }}-{{ distribution }}.{{ architectures[ansible_architecture] }}.{{ format }}
 
 # The packages to install
 package_names:


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Adds automatic detection of the package format and platform architecture.
* Automatically determines the best Nessus package to install given the desired version, based on the Nessus package files that are uploaded to the S3 bucket.
* Adds support and testing for Amazon Linux 2 and Fedora distributions.
* Adds a `molecule` scenario to test installation of the latest version of Nessus.

## 💭 Motivation and context ##

Some assessment groups have indicated that they would like to have the most recent version of Nessus preinstalled in their AMIs.  Whatever is decided by the assessments tech council, this is a useful thing for this Ansible role to support.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.