### PR TITLE
Fix broken build

### DIFF
--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,9 +1,12 @@
 ---
 - hosts: all
-  name: Install pip3/python3 and remove pip2/python2
+  name: Install pip3/python3
   become: yes
   become_method: sudo
   roles:
-    - pip
-    - python
-    - remove_python2
+    - name: pip
+      vars:
+        install_python2: true
+    - name: python
+      vars:
+        install_pip2: true

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -4,9 +4,8 @@
   become: yes
   become_method: sudo
   roles:
-    - name: pip
-      vars:
-        install_python2: true
-    - name: python
-      vars:
-        install_pip2: true
+    - pip
+    - python
+  vars:
+    install_pip2: true
+    install_python2: true

--- a/molecule/default/python.yml
+++ b/molecule/default/python.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  name: Install pip3/python3
+  name: Install pip2/python2 and pip3/python3
   become: yes
   become_method: sudo
   roles:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `molecule` `prepare` playbook to:
- Install Python 2
- Install `pip2`
- Stop removing Python 2 and `pip2`

## 💭 Motivation and context ##

This is required to fix the broken build since this Ansible role requires a Python 2 environment to function.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.