### PR TITLE
Remove installation of boto3 on the remote system

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,12 +4,3 @@
 
 - name: Import python playbook
   ansible.builtin.import_playbook: python.yml
-
-# boto3 is pre-installed anywhere we would be applying this Ansible
-# role
-- name: Install boto3
-  hosts: all
-  tasks:
-    - name: Install boto3
-      ansible.builtin.pip:
-        name: boto3


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the installation of the Boto3 Python package on the remote system.

## 💭 Motivation and context ##

Boto3 is only required on the Ansible controller.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.