### PR TITLE
Upgrade what is considered to be the latest version of Nessus

### DIFF
--- a/molecule/latest/converge.yml
+++ b/molecule/latest/converge.yml
@@ -9,4 +9,4 @@
       ansible.builtin.include_role: # noqa var-naming[no-role-prefix]
         name: ansible-role-nessus
       vars:
-        nessus_version: "10.7.4"
+        nessus_version: "10.8.3"

--- a/molecule/latest/tests/test_latest.py
+++ b/molecule/latest/tests/test_latest.py
@@ -14,7 +14,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 # The version of Nessus that should be installed
-version = "10.7.4"
+version = "10.8.3"
 
 
 def test_packages(host):


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades what is considered to be the latest version of Nessus.  I already uploaded the packages corresponding to the latest version to the third-party bucket.

## 💭 Motivation and context ##

It is important to stay current so we don't get left behind.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.