### PR TITLE
Use Nessus 10.8.4 as latest

### DIFF
--- a/molecule/latest/converge.yml
+++ b/molecule/latest/converge.yml
@@ -10,4 +10,4 @@
         name: ansible-role-nessus
       vars:
         nessus_package_bucket: "{{ lookup('aws_ssm', '/third_party_bucket_name') }}"
-        nessus_version: 10.8.3
+        nessus_version: 10.8.4

--- a/molecule/latest/tests/test_latest.py
+++ b/molecule/latest/tests/test_latest.py
@@ -14,7 +14,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 # The version of Nessus that should be installed
-version = "10.8.3"
+version = "10.8.4"
 
 
 def test_packages(host):


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Molecule testing to use Nessus 10.8.4 as the latest version.

## 💭 Motivation and context ##

We were previously using Nessus 10.8.3 as latest, but that is no longer the latest version.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
